### PR TITLE
Updates MultiCertifier contract to match what was deployed to blockchain.

### DIFF
--- a/src/contracts/MultiCertifier.sol
+++ b/src/contracts/MultiCertifier.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.4.16;
 
 // From Owned.sol
 contract Owned {
-	modifier only_owner { require (msg.sender == owner); _; }
+	modifier only_owner { if (msg.sender != owner) return; _; }
 
 	event NewOwner(address indexed old, address indexed current);
 


### PR DESCRIPTION
Its possible that this difference actually stems from a compiler difference rather than a contract difference, but I wasn't able to find a compiler that generated the bytecode currently on the blockchain while this change when using 0.4.16 with no optimizations matches exactly.